### PR TITLE
Support Marshmallow v3.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # golden-marshmallows
 A better integration between SQLAlchemy and Marshmallow. A little (SQL)alchemy to turn `marshmallow`s into gold.
 
+Note: The default unknown field handling has been defaulted to `EXCLUDE` so it handles
+closer to Marshmallow v2.
+
 # Installation
 Simply install with `pip`:
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ session.flush()
 
 schema = GoldenSchema(Alchemist)
 
-serialized = schema.dump(alchemist).data
+serialized = schema.dump(alchemist)
 
 print(json.dump(serialized, indent=4))
 # {
@@ -77,7 +77,7 @@ session.commit()
 
 schema = GoldenSchema(Alchemist, nested_map=nested_map)
 
-serialized = schema.dump(alchemist).data
+serialized = schema.dump(alchemist)
 
 print(json.dump(serialized, indent=4))
 # {
@@ -113,7 +113,7 @@ session.flush()
 
 schema = GoldenSchema(WizardCollege, nested_map=nested_map)
 
-serialized = schema.dump(college).data
+serialized = schema.dump(college)
 
 print(json.dump(serialized, indent=4))
 # {
@@ -160,7 +160,7 @@ formula.ingredients = ['lead', 'magic']
 
 schema = GoldenSchema(Alchemist, nested_map=nested_map)
 
-serialized = schema.dump(alchemist).data
+serialized = schema.dump(alchemist)
 
 print(json.dump(serialized, indent=4))
 # {
@@ -201,7 +201,7 @@ data = {
     ]
 }
 
-college = schema.load(data).data
+college = schema.load(data)
 print(college)
 # <WizardCollege(name='Bogwarts')>
 print(college.alchemists)
@@ -216,7 +216,7 @@ The `snake_to_camel` flag allows serde to/from camelCase, for example when seria
 # `Formula.author_id` is easily converted to camelCase
 schema = GoldenSchema(Formula, snake_to_camel=True)
 
-serialized = schema.dump(formula).data
+serialized = schema.dump(formula)
 
 print(json.dumps(serialized, indent=4))
 # Notice `author_id` has become `authorId`
@@ -233,7 +233,7 @@ data = {
     "authorId": 1,
     "id": 1
 }
-formula = schema.load(data).data
+formula = schema.load(data)
 
 print(formula.author_id)
 # 1
@@ -247,7 +247,7 @@ class MySchema(GoldenSchema):
 
 my_schema = MySchema(Formula, snake_to_camel=True)
 
-serialized = schema.dump(formula).data
+serialized = schema.dump(formula)
 print(json.dumps(serialized, indent=4))
 # `manually_declared` has become camelCase
 # {
@@ -273,7 +273,7 @@ class SnakeObj:
 schema = SnakeSchema(snake_to_camel=True)
 obj = SnakeObj('field1', 2)
 
-serialized = schema.dump(obj).data
+serialized = schema.dump(obj)
 print(json.dumps(serialized, indent=4))
 # {
 #     'attrOne': 'field1',
@@ -292,7 +292,7 @@ data = {
     "id": 1
 }
 
-new_formula = schema.load(data).data
+new_formula = schema.load(data)
 print(new_formula.title)
 # 'transmutation'
 print(new_formula.id)  # None

--- a/golden_marshmallows/schema.py
+++ b/golden_marshmallows/schema.py
@@ -1,14 +1,12 @@
 import re
 
 from marshmallow import (
-    fields, post_load, Schema)
+    fields, post_load, Schema, EXCLUDE)
 from sqlalchemy.ext.declarative.api import DeclarativeMeta
 from sqlalchemy.dialects.postgresql import (
     ARRAY as pgARRAY, BIGINT, ENUM, TIMESTAMP, UUID)
 from sqlalchemy.sql.sqltypes import (
     ARRAY, Boolean, BOOLEAN, DATE, Integer, INTEGER, JSON, String, TEXT)
-
-
 
 
 def camelcase(string):
@@ -90,24 +88,20 @@ class CaseChangingSchema(Schema):
         self.snake_to_camel = snake_to_camel
         self.camel_to_snake = camel_to_snake
 
-        # This will cause the Schema to actually raise errors by default
-        kwargs.update({'strict': True})
         super(CaseChangingSchema, self).__init__(*args, **kwargs)
 
         self.alter_case()
 
     def alter_case(self):
-        """ Convert all fields to load_from and dump_to the camelCase or
-        snake_case version of each field name.
+        """ Convert all fields to data_key the camelCase or snake_case version
+        of each field name.
         """
         for name, field in self.declared_fields.items():
 
             if self.snake_to_camel:
-                field.load_from = camelcase(name)
-                field.dump_to = camelcase(name)
+                field.data_key = camelcase(name)
             elif self.camel_to_snake:
-                field.load_from = snakecase(name)
-                field.dump_to = snakecase(name)
+                field.data_key = snakecase(name)
 
 
 class GoldenSchema(CaseChangingSchema):
@@ -136,8 +130,8 @@ class GoldenSchema(CaseChangingSchema):
         UUID: fields.UUID
     }
 
-    def __init__(self, sqlalchemy_cls, nested_map={}, new_obj=False,
-                 *args, **kwargs):
+    def __init__(self, sqlalchemy_cls, nested_map=None, new_obj=False,
+                 unknown=EXCLUDE, *args, **kwargs):
         """ Introspects and creates fields for each attribute of the
         given SQLAlchemy class.
 
@@ -152,6 +146,10 @@ class GoldenSchema(CaseChangingSchema):
                 deserialize to new objects; basically just skips adding
                 any field named 'id'
         """
+        nested_map = nested_map if nested_map is not None else {}
+
+        kwargs['unknown'] = unknown
+
         super(GoldenSchema, self).__init__(*args, **kwargs)
 
         self.new_obj = new_obj
@@ -186,6 +184,7 @@ class GoldenSchema(CaseChangingSchema):
                     snake_to_camel=self.snake_to_camel,
                     camel_to_snake=self.camel_to_snake,
                     many=val['many'],
+                    unknown=EXCLUDE,
                     new_obj=self.new_obj)
             elif isinstance(val['class'], GoldenSchema):
                 schema = val['class']
@@ -250,9 +249,6 @@ class GoldenSchema(CaseChangingSchema):
             # allows subclasses of this class to still define custom
             # fields)
             if name not in self.declared_fields:
-                if self.new_obj and name == 'id':
-                    continue
-
                 field.attribute = name
                 if self.snake_to_camel:
                     name = camelcase(name)
@@ -262,7 +258,13 @@ class GoldenSchema(CaseChangingSchema):
                 self.fields[name] = field
                 self.declared_fields[name] = field
 
+                if self.new_obj and name == 'id':
+                    self.exclude.add('id')
+                else:
+                    self.dump_fields[name] = field
+                    self.load_fields[name] = field
+
     @post_load
-    def make_sqlalchemy_object(self, data):
+    def make_sqlalchemy_object(self, data, **kwargs):
         """ Convert deserialized data into a new SQLAlchemy object. """
         return self.sqlalchemy_cls(**data)

--- a/golden_marshmallows/schema.py
+++ b/golden_marshmallows/schema.py
@@ -93,8 +93,8 @@ class CaseChangingSchema(Schema):
         self.alter_case()
 
     def alter_case(self):
-        """ Convert all fields to data_key the camelCase or snake_case version
-        of each field name.
+        """ Perform appropriate case conversion of the `data_key` attribute on
+        each field.
         """
         for name, field in self.declared_fields.items():
 
@@ -184,7 +184,7 @@ class GoldenSchema(CaseChangingSchema):
                     snake_to_camel=self.snake_to_camel,
                     camel_to_snake=self.camel_to_snake,
                     many=val['many'],
-                    unknown=EXCLUDE,
+                    unknown=self.unknown,
                     new_obj=self.new_obj)
             elif isinstance(val['class'], GoldenSchema):
                 schema = val['class']

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,15 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='golden_marshmallows',
-    version='0.3.0',
+    version='1.0.0',
     author='Guillaume Chorn',
     author_email='guillaume.chorn@gmail.com',
     packages=['golden_marshmallows'],
     url='https://github.com/gchorn/golden-marshmallows',
-    download_url='https://github.com/gchorn/golden-marshmallows/archive/v0.2.1.tar.gz',
+    download_url='https://github.com/gchorn/golden-marshmallows/archive/v1.0.0.tar.gz',
     description='Marshmallow Schema subclass that auto-defines fields based on'
                 ' SQLAlchemy classes',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    install_requires=['marshmallow<3', 'SQLAlchemy']
+    install_requires=['marshmallow', 'SQLAlchemy']
 )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -39,7 +39,7 @@ class TestCaseChangingSchema:
             'attrOne': 'field1',
             'attrTwo': 2
         }
-        result = tschema.dump(tobj).data
+        result = tschema.dump(tobj)
 
         assert result == expected
 
@@ -51,7 +51,7 @@ class TestCaseChangingSchema:
             'attr_one': 'field1',
             'attr_two': 2
         }
-        result = tschema.dump(tobj).data
+        result = tschema.dump(tobj)
 
         assert result == expected
 
@@ -90,7 +90,7 @@ class TestGoldenSchema:
     def test_serialization(self):
         gs = GoldenSchema(WizardCollege, nested_map=self.nested_map)
 
-        serialized = gs.dump(self.school).data
+        serialized = gs.dump(self.school)
 
         expected = {
             "id": 1,
@@ -120,7 +120,7 @@ class TestGoldenSchema:
 
         gs = GoldenSchema(WizardCollege, nested_map=self.nested_map)
 
-        serialized = gs.dump(self.school).data
+        serialized = gs.dump(self.school)
 
         expected = {
             "id": 1,
@@ -154,7 +154,7 @@ class TestGoldenSchema:
 
         self.school.alchemists[0].formulae[0].ingredients = ['magic', 'lead']
 
-        serialized = gs.dump(self.school).data
+        serialized = gs.dump(self.school)
 
         expected = {
             "id": 1,
@@ -200,7 +200,7 @@ class TestGoldenSchema:
             ]
         }
 
-        college = gs.load(serialized).data
+        college = gs.load(serialized)
 
         assert isinstance(college, WizardCollege)
         assert college.id == 1
@@ -239,7 +239,7 @@ class TestGoldenSchema:
             'name': 'Albertus Magnus'
         }
 
-        deserialized = gs.load(serialized).data
+        deserialized = gs.load(serialized)
 
         assert isinstance(deserialized, Alchemist)
         assert deserialized.id is None
@@ -255,7 +255,7 @@ class TestGoldenSchema:
             nested_map=self.nested_map['alchemists']['nested_map'],
             snake_to_camel=True)
 
-        serialized = gs.dump(self.alchemist).data
+        serialized = gs.dump(self.alchemist)
 
         expected = {
             'formulae': [
@@ -279,7 +279,7 @@ class TestGoldenSchema:
         camel_formula = CamelFormula(
             id=1, title='transmutation', camelAttribute='value')
 
-        serialized = gs.dump(camel_formula).data
+        serialized = gs.dump(camel_formula)
 
         expected = {
             'camel_attribute': 'value',
@@ -299,7 +299,7 @@ class TestGoldenSchema:
             nested_map=self.nested_map['alchemists']['nested_map'],
             snake_to_camel=True)
 
-        serialized = gs.dump(self.alchemist).data
+        serialized = gs.dump(self.alchemist)
 
         expected = {
             'formulae': [
@@ -328,7 +328,7 @@ class TestGoldenSchema:
         camel_formula = CamelFormula(
             id=1, title='transmutation', camelAttribute='value')
 
-        serialized = gs.dump(camel_formula).data
+        serialized = gs.dump(camel_formula)
 
         expected = {
             'camel_attribute': 'value',


### PR DESCRIPTION
This PR supports the latest version of marshmallow.  Please make sure to look at how I handled the removal of the 'id' field within the nested records.

I didn't fully understand why this was being setup, so I did my best to make sure the tests still passed without modification. Marshmallow v2 ignored extra fields, and v3 asserts when they exist.


```
$ pytest
====================================== test session starts ======================================
platform darwin -- Python 3.8.0, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /Users/kyle.walker/work/golden-marshmallows-updated
plugins: pudb-0.7.0
collected 12 items

tests/test_schema.py ............                                                          [100%]

====================================== 12 passed in 0.32s ======================================
```